### PR TITLE
import FoundationNetworking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swiftlint:swift-5
+FROM norionomura/swiftlint:swift-5.1.1
 LABEL version="2.1.0"
 LABEL repository="https://github.com/norio-nomura/action-swiftlint"
 LABEL homepage="https://github.com/norio-nomura/action-swiftlint"

--- a/Sources/Lib/GitHub.swift
+++ b/Sources/Lib/GitHub.swift
@@ -1,6 +1,8 @@
 import Dispatch
 import Foundation
+#if canImport(FoundationNetworking)
 import FoundationNetworking
+#endif
 
 public enum GitHub {
     public static let baseURL = URL(string: "https://api.github.com")!

--- a/Sources/Lib/GitHub.swift
+++ b/Sources/Lib/GitHub.swift
@@ -1,5 +1,6 @@
 import Dispatch
 import Foundation
+import FoundationNetworking
 
 public enum GitHub {
     public static let baseURL = URL(string: "https://api.github.com")!

--- a/Tests/action-swiftlintTests/action_swiftlintTests.swift
+++ b/Tests/action-swiftlintTests/action_swiftlintTests.swift
@@ -12,11 +12,11 @@ final class action_swiftlintTests: XCTestCase {
             "Can not find `GITHUB_TOKEN` environment variable.\n" : ""
 
         XCTAssertEqual(output, """
-Sources/Lib/GitHub.swift:45:16: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
-Sources/Lib/GitHub.swift:140:9: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
-Sources/Lib/GitHub.swift:152:9: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
-Sources/Lib/GitHub.swift:153:13: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
-Sources/Lib/GitHub.swift:153:13: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
+Sources/Lib/GitHub.swift:48:16: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
+Sources/Lib/GitHub.swift:143:9: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
+Sources/Lib/GitHub.swift:155:9: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
+Sources/Lib/GitHub.swift:156:13: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
+Sources/Lib/GitHub.swift:156:13: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
 Sources/Lib/SwiftLint.swift:6:16: warning: Nesting Violation: Types should be nested at most 1 level deep (nesting)
 Sources/Lib/execute().swift:4:68: warning: Large Tuple Violation: Tuples should have at most 2 members. (large_tuple)
 \(warningMessage)


### PR DESCRIPTION
Building the Docker image in the root directory fails because the compiler can't find the definition of `URLRequest` & `URLSession`. According to the warnings, what's missing is importing the module `FoundationNetworking`.

This PR imports that module to fix the issue and updates the version of Swift to 5.1.1.