### PR TITLE
Add PROJECT_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ jobs:
         uses: norio-nomura/action-swiftlint@3.1.0
         env:
           DIFF_BASE: ${{ github.base_ref }}
+      - name: GitHub Action for SwiftLint in another directory
+        uses: norio-nomura/action-swiftlint@3.1.0
+        env:
+          PROJECT_PATH: ./my-app
 ```
 
 ## Secrets

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,15 +11,20 @@ function convertToGitHubActionsLoggingCommands() {
     sed -E 's/^(.*):([0-9]+):([0-9]+): (warning|error|[^:]+): (.*)/::\4 file=\1,line=\2,col=\3::\5/'
 }
 
+if ! ${PROJECT_PATH+false};
+then
+   cd ${PROJECT_PATH}
+fi
+
 if ! ${DIFF_BASE+false};
 then
-	changedFiles=$(git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD $DIFF_BASE) -- '*.swift')
+    changedFiles=$(git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD $DIFF_BASE) -- '*.swift')
 
-	if [ -z "$changedFiles" ]
-	then
-		echo "No Swift file changed"
-		exit
-	fi
+    if [ -z "$changedFiles" ]
+    then
+        echo "No Swift file changed"
+        exit
+    fi
 fi
 
 set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands


### PR DESCRIPTION
This PR adds a PROJECT_PATH environment variable if you want to execute SwiftLint in different directory.

(also replace tabs with spaces in entrypoint.sh)