### PR TITLE
Use --reporter github-actions-logging option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 
-# convert swiftlint's output into GitHub Actions Logging commands
-# https://help.github.com/en/github/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands
-
-function stripPWD() {
-    sed -E "s/$(pwd|sed 's/\//\\\//g')\///"
-}
-
-function convertToGitHubActionsLoggingCommands() {
-    sed -E 's/^(.*):([0-9]+):([0-9]+): (warning|error|[^:]+): (.*)/::\4 file=\1,line=\2,col=\3::\5/'
-}
-
 if ! ${DIFF_BASE+false};
 then
 	changedFiles=$(git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD $DIFF_BASE) -- '*.swift')
@@ -22,4 +11,4 @@ then
 	fi
 fi
 
-set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands
+set -o pipefail && swiftlint "$@" --reporter github-actions-logging -- $changedFiles


### PR DESCRIPTION
👋 Nice Action!

I wasn't aware of it until after I was digging into the SwiftLint source code, but there is actually a reporter that formats for the GitHub Action so we can avoid having to `sed` stdout from now on 🚀 

(The reporter wasn't documented in SwiftLint's Readme but I've added it here: realm/SwiftLint/pull/3223)

I ran this on my test project and it seems to work, but please feel free to give it a try yourself first 🙏 