### PR TITLE
Add optional WORKING_DIRECTORY environment variable and fix test run (#33)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Exit Status on Warnings with `--strict`
         run: |
           STATUS=$(docker run -v $(pwd):$(pwd) -w $(pwd) --rm action-swiftlint --strict &>/dev/null; echo $?)
-          [[ $STATUS == "3" ]]
+          [[ $STATUS == "2" ]]
         working-directory: ./test/Warnings
         shell: bash
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,3 +61,8 @@ jobs:
         run: diff <(docker run -v $(pwd):$(pwd) -w $(pwd) --rm action-swiftlint|sort) expected.txt
         working-directory: ./test/Warnings
         shell: bash
+
+      - name: Output on Warnings with WORKING_DIRECTORY environment variable
+        run: diff <(docker run -v $(pwd):$(pwd) -w $(pwd) --rm --env WORKING_DIRECTORY=Warnings action-swiftlint|sort) Warnings/expected.txt
+        working-directory: ./test
+        shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM norionomura/swiftlint:swift-5.1
 LABEL version="3.1.0"
-LABEL repository="https://github.com/m-herold/action-swiftlint"
-LABEL homepage="https://github.com/m-herold/action-swiftlint"
+LABEL repository="https://github.com/norio-nomura/action-swiftlint"
+LABEL homepage="https://github.com/norio-nomura/action-swiftlint"
 LABEL maintainer="Norio Nomura <norio.nomura@gmail.com>"
 
 LABEL "com.github.actions.name"="GitHub Action for SwiftLint"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM norionomura/swiftlint:swift-5.1
 LABEL version="3.1.0"
-LABEL repository="https://github.com/norio-nomura/action-swiftlint"
-LABEL homepage="https://github.com/norio-nomura/action-swiftlint"
+LABEL repository="https://github.com/m-herold/action-swiftlint"
+LABEL homepage="https://github.com/m-herold/action-swiftlint"
 LABEL maintainer="Norio Nomura <norio.nomura@gmail.com>"
 
 LABEL "com.github.actions.name"="GitHub Action for SwiftLint"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ jobs:
         uses: norio-nomura/action-swiftlint@3.1.0
         env:
           DIFF_BASE: ${{ github.base_ref }}
+      - name: GitHub Action for SwiftLint (Different working directory)
+        uses: norio-nomura/action-swiftlint@3.1.0
+        env:
+          WORKING_DIRECTORY: Source
 ```
 
 ## Secrets

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,14 @@ function convertToGitHubActionsLoggingCommands() {
     sed -E 's/^(.*):([0-9]+):([0-9]+): (warning|error|[^:]+): (.*)/::\4 file=\1,line=\2,col=\3::\5/'
 }
 
+if ! ${WORKING_DIRECTORY+false};
+then
+	cd ${WORKING_DIRECTORY}
+fi
+
 if ! ${DIFF_BASE+false};
 then
-	changedFiles=$(git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD $DIFF_BASE) -- '*.swift')
+	changedFiles=$(git --no-pager diff --name-only --relative FETCH_HEAD $(git merge-base FETCH_HEAD $DIFF_BASE) -- '*.swift')
 
 	if [ -z "$changedFiles" ]
 	then


### PR DESCRIPTION
Add an optional `WORKING_DIRECTORY` environment variable which allows to run this GitHub action in a subdirectory (i.e., in case your code and `.swiftlint.yml` configuration file do not reside in the root of your repository). These changes also work in combination with the `DIFF_BASE` environment variable.

This pull request also fixes the test run, since with SwiftLint version 0.41.0, SwiftLint has also changed the exit status on warnings in case you are using the `--strict` option (https://github.com/realm/SwiftLint/pull/3372/files#diff-5b9fa80336289abd42b297396f8eceb078430b385bd97439cb720a46896f4cefR65).

Please note: this was not necessary prior to SwiftLint version 0.41.0. With that version SwiftLint has changed the calculation of the root path when a directory in the tree is passed as `path` argument.

Prior to this version it was possible to define a path argument, whereas SwiftLint then took the config file and all excluded files relative to this path argument. This seems to have changed, whereas this awesome GitHub action does not work properly anymore in the case (a) your source code is not located in the root folder of your repository, and (b) you have defined excluded files/path in a configuration file which are relative to this source code folder (e.g., to be used within an Xcode build phase). In those cases this GitHub action can not be used anymore, due to the following changes of SwiftLint:

realm/SwiftLint@6d77deb


For further details please see #33.