### PR TITLE
Fix GitHub annotation for using WORKING_DIRECTORY environment variable

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -63,6 +63,6 @@ jobs:
         shell: bash
 
       - name: Output on Warnings with WORKING_DIRECTORY environment variable
-        run: diff <(docker run -v $(pwd):$(pwd) -w $(pwd) --rm --env WORKING_DIRECTORY=Warnings action-swiftlint|sort) Warnings/expected.txt
+        run: diff <(docker run -v $(pwd):$(pwd) -w $(pwd) --rm --env WORKING_DIRECTORY=Warnings action-swiftlint|sort) <(cat Warnings/expected.txt | sed -E 's/^(.*)file=(.*),(.*)/\1file=Warnings\/\2,\3/')
         working-directory: ./test
         shell: bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,10 @@
 # https://help.github.com/en/github/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands
 
 function stripPWD() {
+    if ! ${WORKING_DIRECTORY+false};
+    then
+        cd - > /dev/null
+    fi
     sed -E "s/$(pwd|sed 's/\//\\\//g')\///"
 }
 


### PR DESCRIPTION
When using the newly introduced optional `WORKING_DIRECTORY` environment variable (#34), the output of this GitHub action, meaning all warnings and errors, is relative to the given `WORKING_DIRECTORY`. While the action correctly fails or succeeds, the annotations are not displayed correctly within a pull request's "Files changed" tab.

In order to fix this problem, the _file_ parameter in the output should always be an absolute path, starting from the root of the GitHub repository, also when using the `WORKING_DIRECTORY`environment variable. Example:

`::warning file=Working-Directory/Package.swift,line=12,col=33::Trailing Comma Violation: Collection literals should not have trailing commas. (trailing_comma)`