### PR TITLE
Add option to select DIFF_HEAD for changed files comparsion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ jobs:
         uses: norio-nomura/action-swiftlint@3.2.1
         env:
           DIFF_BASE: ${{ github.base_ref }}
+          DIFF_HEAD: ${{ github.head_ref }}
       - name: GitHub Action for SwiftLint (Different working directory)
         uses: norio-nomura/action-swiftlint@3.2.1
         env:

--- a/README.md
+++ b/README.md
@@ -21,17 +21,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      // Simple usage
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1
+      // With custom argument
       - name: GitHub Action for SwiftLint with --strict
         uses: norio-nomura/action-swiftlint@3.2.1
         with:
           args: --strict
+      // Only checks files changed in the PR
+      - name: Fetch base ref
+        run: |
+          git fetch --prune --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/heads/${{ github.base_ref }}
       - name: GitHub Action for SwiftLint (Only files changed in the PR)
         uses: norio-nomura/action-swiftlint@3.2.1
         env:
           DIFF_BASE: ${{ github.base_ref }}
-          DIFF_HEAD: ${{ github.head_ref }}
+          DIFF_HEAD: HEAD
+      // Runs on different workspace
       - name: GitHub Action for SwiftLint (Different working directory)
         uses: norio-nomura/action-swiftlint@3.2.1
         env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ then
 fi
 
 if [ -n "$DIFF_BASE" ] && [ -n "$DIFF_HEAD" ]; then
-	changedFiles=$(git --no-pager diff --name-only --relative $DIFF_HEAD $(git merge-base $DIFF_HEAD $DIFF_BASE) -- '*.swift')
+	changedFiles=$(git --no-pager diff --name-only --relative $DIFF_HEAD $DIFF_BASE -- '*.swift')
 
 	if [ -z "$changedFiles" ]
 	then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ then
 	cd ${WORKING_DIRECTORY}
 fi
 
-if [[ -z $DIFF_BASE && -z $DIFF_HEAD ]]; then
+if [ -n "$DIFF_BASE" ] && [ -n "$DIFF_HEAD" ]; then
 	changedFiles=$(git --no-pager diff --name-only --relative $DIFF_HEAD $(git merge-base $DIFF_HEAD $DIFF_BASE) -- '*.swift')
 
 	if [ -z "$changedFiles" ]
@@ -28,6 +28,7 @@ if [[ -z $DIFF_BASE && -z $DIFF_HEAD ]]; then
 		echo "No Swift file changed"
 		exit
 	fi
+	
 fi
 
 set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,14 @@ if [ -n "$DIFF_BASE" ] && [ -n "$DIFF_HEAD" ]; then
 		echo "No Swift file changed"
 		exit
 	fi
-	
+elif [ -n "$DIFF_BASE" ]; then
+	changedFiles=$(git --no-pager diff --name-only --relative FETCH_HEAD $(git merge-base FETCH_HEAD $DIFF_BASE) -- '*.swift')
+
+	if [ -z "$changedFiles" ]
+	then
+		echo "No Swift file changed"
+		exit
+	fi
 fi
 
 set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,9 +20,8 @@ then
 	cd ${WORKING_DIRECTORY}
 fi
 
-if ! ${DIFF_BASE+false};
-then
-	changedFiles=$(git --no-pager diff --name-only --relative FETCH_HEAD $(git merge-base FETCH_HEAD $DIFF_BASE) -- '*.swift')
+if [[ -z $DIFF_BASE && -z $DIFF_HEAD ]]; then
+	changedFiles=$(git --no-pager diff --name-only --relative $DIFF_HEAD $(git merge-base $DIFF_HEAD $DIFF_BASE) -- '*.swift')
 
 	if [ -z "$changedFiles" ]
 	then


### PR DESCRIPTION
There's an issue report on https://github.com/norio-nomura/action-swiftlint/issues/23. The `DIFF_BASE: ${{ github.base_ref }}` may not work in some cases, for example, the pull_request checking. The reason for that is: For the pull_request, the `actions/checkout` will set the HEAD to the `refs/remotes/pull/{PR_NUMBER}/merge,` but the `${{ github.base_ref }}` isn't set. So we have to fetch the `${{ github manually.base_ref }}` (usually the master). The original diff comparison only runs on `FETCH_HEAD` and given `base_ref.` But in this case, the `FETCH_HEAD` will be the `base_ref` because we call the `git fetch.` Therefore, I set up a customizable `HEAD` and `BASE` parameters gives us more flexibility to deal with more jobs scenario, like the above case.

And for the backward compatibility, I didn't remove the old implement to ensure the others won't break.

```
name: CI

on: pull_request

jobs:
  PR-Check:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: Fetch base ref
        if: ${{ always() }}
        run: |
          git fetch --prune --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/heads/${{ github.base_ref }}
      - name: SwiftLint (Only files changed in the PR)
        if: ${{ always() }}
        uses: henry2423/action-swiftlint@Fix-PR-Lint
        with:
          args: --force-exclude --strict --config build-swiftlint.yml
        env:
           DIFF_BASE: ${{ github.base_ref }}
           DIFF_HEAD: HEAD
```