### PR TITLE
Add output parameters 'violations_count' and 'serious_violations_count'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swiftlint:0.58.2
+FROM norionomura/swiftlint:0.59.1-slim
 LABEL version="3.2.1"
 LABEL repository="https://github.com/norio-nomura/action-swiftlint"
 LABEL homepage="https://github.com/norio-nomura/action-swiftlint"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swiftlint:swift-5
+FROM norionomura/swiftlint:0.58.2
 LABEL version="3.2.1"
 LABEL repository="https://github.com/norio-nomura/action-swiftlint"
 LABEL homepage="https://github.com/norio-nomura/action-swiftlint"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,11 @@
 name: 'GitHub Action for SwiftLint'
 description: 'A tool to enforce Swift style and conventions'
 author: 'Norio Nomura <norio.nomura@gmail.com>'
+outputs:
+  violations_count:
+    description: 'Number of found violations'
+  serious_violations_count:
+    description: 'Number of serious violations'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,16 @@ function convertToGitHubActionsLoggingCommands() {
     sed -E 's/^(.*):([0-9]+):([0-9]+): (warning|error|[^:]+): (.*)/::\4 file=\1,line=\2,col=\3::\5/'
 }
 
+function parseOutputsParameters() {
+   input_value=$( cat )
+   violations=$(echo "$input_value" | grep -E '::warning|::error' -c)
+   errors=$(echo "$input_value" | grep -E 'error' -c)
+   echo "$input_value"
+   echo "::set-output name=violations_count::$violations"
+   echo "::set-output name=serious_violations_count::$errors"
+}
+
+
 if ! ${WORKING_DIRECTORY+false};
 then
 	cd ${WORKING_DIRECTORY}
@@ -31,4 +41,4 @@ then
 	fi
 fi
 
-set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands
+set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands | parseOutputsParameters

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,4 +41,5 @@ then
 	fi
 fi
 
+echo "Using swiftlint version: `swiftlint --version`"
 set -o pipefail && swiftlint "$@" -- $changedFiles | stripPWD | convertToGitHubActionsLoggingCommands | parseOutputsParameters


### PR DESCRIPTION
Adds the ability to check the number of violations and serious violations to fail action if outside of requirements.

For example, to make sure that no more than 6 violations are allow change the `.github/workflows/swiftlint.yml` to add the following step:

```
      - name: Check Violations number
        if:  ${{ steps.swift-lint.outputs.violations_count > 6 }}
        run: |
            echo "::error::This PR exceed maximum number of allowed violations (6). Actual number is (${{ steps.swift-lint.outputs.violations_count }})"
            exit 1
        shell: bash
```